### PR TITLE
Fix UG tab

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,3 +1,7 @@
+---
+layout: page
+title: User Guide
+---
 NUS Classes is a desktop app for NUS Computing professors to manage their tasks and contacts. It includes task management features such as 
 creating tasks, tagging tasks, assigning contacts to tasks, and marking tasks as complete or incomplete. It also includes contact management features such as finding contacts, assigning contacts to specific tasks and tagging contacts. 
 


### PR DESCRIPTION
The GitHub deployment couldn't detect the `User Guide` (hence no `User Guide` tab on the deployment page)