### PR TITLE
Fix import command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -528,16 +528,16 @@ If your changes to the data file makes its format invalid, NUS Classes will disc
 
 Imports a list of contacts from a .csv file.
 
-**Format**: `import fp/FILENAME`
+**Format**: `import fp/FILEPATH`
 
 * The .csv file must contain the following 5 headers (Name, Phone, Email, Github, Tags). Any other headers will be ignored.
-* Tags in the .csv file should be separated with a `/` character.
 * If there are repeated headers, the first one will be considered.
+* Tags in the .csv file should be separated with a `/` character.
 * Invalid csv entries (e.g. due to invalid or duplicate fields) will be skipped, but valid entries will still be added.
 
 **Examples**:
 * `import fp/data/data.csv` will import all valid entries from the `data.csv` folder in the `/data` directory of the NUS Classes folder.
-
+* `import fp/contacts.csv` will import all valid entries from the `contacts.csv file` in the NUS Classes root folder
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_FILEPATH;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.util.TagUtil;
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILEPATH;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -22,9 +23,11 @@ import seedu.address.model.tag.Tag;
 
 public class ImportCommandParser implements Parser<ImportCommand> {
 
-    public static final String MESSAGE_CSV_MISSING_HEADERS = "Missing headers in the file %s";
+    public static final String MESSAGE_CSV_MISSING_HEADERS = "Missing headers in the file \"%s\"";
 
-    public static final String MESSAGE_CSV_MISSING_FIELD = "Error: found empty field in the file %s";
+    public static final String MESSAGE_CSV_MISSING_FIELD = "Error: found empty field in the file \"%s\"";
+
+    public static final String MESSAGE_FILE_DOES_NOT_EXIST = "Error: could not find the file \"%s\".";
 
 
     /**
@@ -40,14 +43,18 @@ public class ImportCommandParser implements Parser<ImportCommand> {
             throw new ParseException(ImportCommand.MESSAGE_USAGE);
         }
 
-        Path path = ParserUtil.parsePath(argMultimap.getValue(PREFIX_FILEPATH));
+        File file = ParserUtil.parsePath(argMultimap.getValue(PREFIX_FILEPATH)).toFile();
+
+        if (!file.exists()) {
+            throw new ParseException(String.format(MESSAGE_FILE_DOES_NOT_EXIST, file.getName()));
+        }
 
         List<Person> toAdd = new ArrayList<>();
 
         List<String> invalidFields = new ArrayList<>();
 
         try {
-            Scanner sc = new Scanner(path.toFile());
+            Scanner sc = new Scanner(file);
             List<String> columns = Arrays.asList(sc.nextLine().split(","));
             int nameIndex = columns.indexOf("Name");
             int phoneIndex = columns.indexOf("Phone");
@@ -56,7 +63,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
             int tagsIndex = columns.indexOf("Tags");
 
             if (List.of(nameIndex, phoneIndex, emailIndex, githubIndex, tagsIndex).contains(-1)) {
-                throw new ParseException(String.format(MESSAGE_CSV_MISSING_FIELD, path.getFileName()));
+                throw new ParseException(String.format(MESSAGE_CSV_MISSING_FIELD, file.getPath()));
             }
 
             while (sc.hasNextLine()) {
@@ -100,7 +107,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
             }
 
         } catch (FileNotFoundException e) {
-            throw new ParseException(String.format(MESSAGE_CSV_MISSING_HEADERS, path.getFileName()));
+            throw new ParseException(String.format(MESSAGE_CSV_MISSING_HEADERS, file.getPath()));
         }
 
         return new ImportCommand(toAdd, argMultimap.getValue(PREFIX_FILEPATH).get(), invalidFields);

--- a/src/test/data/data.csv
+++ b/src/test/data/data.csv
@@ -2,5 +2,5 @@ Name,Phone,Email,Github,Tags
 Alex Tan,97013404,e0315898@u.nus.edu,alexcoder,Student/Lab 14C
 Brad Tay,97553402,e03158448@u.nus.edu,braddytay,TA/Lab 12F/
 Charlie Yeo,97012344,e0323898@u.nus.edu,charlcodes,Graduate Tutor/Lab 14F
-Tag too long guy,97142342,e3240921@u.nus.edu,mythingtoolong,Shamahamunawefoiajowefijawefiojfawefoijwafiwjefaoweifjeawefawefafwfawfwaefaewf
+Tag too long guy,97142342,e3240921@u.nus.edu,mythingtoolong,Shamahamunawefoiajowefijawefiojfawefoijwafiwjefaoawefawefaweweifjeawefawefafwfawfwaefaewf/af
 Missing Field Guy,,e3240921@u.nus.edu,missingdude,Student


### PR DESCRIPTION
UG: add one more example to avoid assumption that the file must be in /data folder

ImportCommand: remove duplicate name check
abstract out converting person list to string

ImportCommandParser: show a different message if file does not exist

fixes #242 