### PR TITLE
Change validation regex for names

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "A name should only contain alphabets, valid symbols (commas, full stops, slashes, apostrophes and hyphens)"
+                    + " and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[a-zA-z,./'-][a-zA-z ,./'-]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,14 +10,15 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "A name should only contain alphabets, valid symbols (commas, full stops, slashes, apostrophes and hyphens)"
+            "A name should only contain alphabets, valid symbols "
+                    + "(commas, full stops, slashes, apostrophes and hyphens)"
                     + " and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[a-zA-z,./'-][a-zA-z ,./'-]*";
+    public static final String VALIDATION_REGEX = "[a-zA-z,./'-][a-zA-z ,./'-]*";
 
     public final String fullName;
 

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -27,14 +27,18 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
-        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("$#")); // only non-alphanumeric characters
+        assertFalse(Name.isValidName("12345")); // numbers only
+        assertFalse(Name.isValidName("peter*")); // contains invalid symbols
+        assertFalse(Name.isValidName("peter the 2nd")); // alphanumeric characters
 
         // valid name
-        assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("peter jack")); // alphabets only
+        assertTrue(Name.isValidName("David Roger Jackson Ray Jr Second")); // long names
+        assertTrue(Name.isValidName("John O'Reilly")); // name with apostrophes
+        assertTrue(Name.isValidName("Martin Luther King, Jr.")); // name with full stop and comma
+        assertTrue(Name.isValidName("Alex Smith-Jones")); // name with hyphen
+        assertTrue(Name.isValidName("Rajesh s/o Koothrapali")); // name with slash
     }
 }


### PR DESCRIPTION
Allow commas, full stops, slashes, apostrophes and hyphens

Valid names under this scheme:
Martin Luther King, Jr. 
Rajesh s/o Koothrapali 
George O'Reilly 
Alex Smith-Jones

Remove numbers from regex (doesn't make sense to have numbers in names)

fixes #196 